### PR TITLE
Set a to and from port

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,30 @@ I mean, what.
 
 Add this resource after you have added the target:
 
-    new AllowConnectionsToECSServiceFromNetworkLoadBalancer(stack, 'AllowServiceFromNLB', {
-        service,
-        port: 80,
-        loadBalancer: nlb,
-    });
+```js
+new AllowConnectionsToECSServiceFromNetworkLoadBalancer(stack, 'AllowServiceFromNLB', {
+    service,
+    fromPort: 80,
+    toPort: 8000,
+    loadBalancer: nlb,
+});
+```
 
 For example:
 
-    const listener = nlb.addListener('Listener', {
-        port: 443,
-        certificates: [ListenerCertificate.fromCertificateManager(certificate)],
-    });
-    listener.addTargets(serviceName, {
-        port: 80,
-        targets: [service],
-    });
-    new AllowConnectionsToECSServiceFromNetworkLoadBalancer(stack, 'AllowServiceFromNLB', {
-        service,
-        port: 80,
-        loadBalancer: nlb,
-    });
-
+```js
+const listener = nlb.addListener('Listener', {
+    port: 443,
+    certificates: [ListenerCertificate.fromCertificateManager(certificate)],
+});
+listener.addTargets(serviceName, {
+    port: 80,
+    targets: [service],
+});
+new AllowConnectionsToECSServiceFromNetworkLoadBalancer(stack, 'AllowServiceFromNLB', {
+    service,
+    fromPort: 80,
+    toPort: 8000,
+    loadBalancer: nlb,
+});
+```

--- a/index.ts
+++ b/index.ts
@@ -43,13 +43,15 @@ export class AllowConnectionsToECSServiceFromNetworkLoadBalancerProvider extends
 export class AllowConnectionsToECSServiceFromNetworkLoadBalancerProps {
     readonly service: ecs.Ec2Service;
     readonly loadBalancer: elbv2.NetworkLoadBalancer;
-    readonly port: number;
+    readonly fromPort: number;
+    readonly toPort: number;
 }
 
 export class AllowConnectionsToECSServiceFromNetworkLoadBalancer extends cdk.Construct {
     public readonly service: ecs.Ec2Service;
     public readonly loadBalancer: elbv2.NetworkLoadBalancer;
-    public readonly port: number;
+    public readonly fromPort: number;
+    public readonly toPort: number;
     private resource: cfn.CustomResource;
 
     constructor(scope: cdk.Construct, id: string, props: AllowConnectionsToECSServiceFromNetworkLoadBalancerProps) {
@@ -60,19 +62,25 @@ export class AllowConnectionsToECSServiceFromNetworkLoadBalancer extends cdk.Con
         if (!props.loadBalancer) {
             throw new Error("No load balancer specified");
         }
-        if (!props.port) {
-            throw new Error("No port specified");
+        if (!props.fromPort) {
+            throw new Error("No fromPort specified");
         }
+        if (!props.toPort) {
+            throw new Error("No toPort specified");
+        }
+
         this.service = props.service;
         this.loadBalancer = props.loadBalancer;
-        this.port = props.port;
+        this.fromPort = props.fromPort;
+        this.toPort = props.toPort;
         this.resource = new cfn.CustomResource(this, 'Resource', {
             provider: AllowConnectionsToECSServiceFromNetworkLoadBalancerProvider.getOrCreate(this),
             resourceType: 'Custom::AllowConnectionsToECSServiceFromNetworkLoadBalancer',
             properties: {
                 ServiceSecurityGroupId: this.service.connections.securityGroups[0].securityGroupId,
                 LoadBalancerArn: this.loadBalancer.loadBalancerArn,
-                Port: this.port,
+                FromPort: this.fromPort,
+                ToPort: this.toPort,
             }
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "allow-connections-to-ecs-service-from-network-load-balancer-cdk",
-  "version": "1.0.0",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1338,6 +1338,16 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.20",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.20.tgz",
+      "integrity": "sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^26.0.0",
+        "pretty-format": "^26.0.0"
+      }
+    },
     "@types/node": {
       "version": "14.0.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.10.tgz",
@@ -1700,6 +1710,15 @@
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
       "dev": true
+    },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
     },
     "bser": {
       "version": "2.1.1",
@@ -3569,6 +3588,15 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -3577,6 +3605,12 @@
       "requires": {
         "semver": "^6.0.0"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.11",
@@ -3674,6 +3708,12 @@
           }
         }
       }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -4948,6 +4988,78 @@
         "punycode": "^2.1.1"
       }
     },
+    "ts-jest": {
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.0.tgz",
+      "integrity": "sha512-Ya4IQgvIFNa2Mgq52KaO8yBw2W8tWp61Ecl66VjF0f5JaV8u50nGoptHVILOPGoI7SDnShmEqnYQEmyHdQ+56g==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "26.x",
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^26.1.0",
+        "json5": "2.x",
+        "lodash": "4.x",
+        "make-error": "1.x",
+        "mkdirp": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
+          "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/istanbul-reports": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+          "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-report": "*"
+          }
+        },
+        "jest-util": {
+          "version": "26.6.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.6.2.tgz",
+          "integrity": "sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.6.2",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
+        }
+      }
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -5258,6 +5370,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/aws-lambda": "^8.10.53",
     "@types/node": "^14.0.10",
     "jest": "^26.0.1",
+    "ts-jest": "^26.5.0",
     "typescript": "^3.9.3"
   }
 }


### PR DESCRIPTION
Thank you so much for creating this library, you saved me a ton of time!

Here is a change that I think could be beneficial for users that accept requests on one port of their NLB but their service accepts on another port.

It might be nice to set the `toPort` with the `fromPort` if `toPort` is empty. Let me know what you think.

I created a package to test it out if that helps: https://www.npmjs.com/package/actesfnlbc