### PR TITLE
Recovered changes from release 1.0.10 on npm

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -43,13 +43,11 @@ export class AllowConnectionsToECSServiceFromNetworkLoadBalancerProvider extends
 export class AllowConnectionsToECSServiceFromNetworkLoadBalancerProps {
     readonly service: ecs.Ec2Service;
     readonly loadBalancer: elbv2.NetworkLoadBalancer;
-    readonly port: number;
 }
 
 export class AllowConnectionsToECSServiceFromNetworkLoadBalancer extends cdk.Construct {
     public readonly service: ecs.Ec2Service;
     public readonly loadBalancer: elbv2.NetworkLoadBalancer;
-    public readonly port: number;
     private resource: cfn.CustomResource;
 
     constructor(scope: cdk.Construct, id: string, props: AllowConnectionsToECSServiceFromNetworkLoadBalancerProps) {
@@ -60,19 +58,14 @@ export class AllowConnectionsToECSServiceFromNetworkLoadBalancer extends cdk.Con
         if (!props.loadBalancer) {
             throw new Error("No load balancer specified");
         }
-        if (!props.port) {
-            throw new Error("No port specified");
-        }
         this.service = props.service;
         this.loadBalancer = props.loadBalancer;
-        this.port = props.port;
         this.resource = new cfn.CustomResource(this, 'Resource', {
             provider: AllowConnectionsToECSServiceFromNetworkLoadBalancerProvider.getOrCreate(this),
             resourceType: 'Custom::AllowConnectionsToECSServiceFromNetworkLoadBalancer',
             properties: {
                 ServiceSecurityGroupId: this.service.connections.securityGroups[0].securityGroupId,
                 LoadBalancerArn: this.loadBalancer.loadBalancerArn,
-                Port: this.port,
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allow-connections-to-ecs-service-from-network-load-balancer-cdk",
-  "version": "1.0.7",
+  "version": "1.0.10",
   "description": "Configure an ECS Service security group to allow connections from a network load balancer",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Got the tarball from npm with:
```
$ wget "$(npm view allow-connections-to-ecs-service-from-network-load-balancer-cdk@1.0.10 dist.tarball)"
```
and found that the source `.ts` files for both `index.ts` and `provider/index.ts` were in npm anyway, so have just copied those in.

So I have not had to unpick any built `.js` back into `.ts`, so I am fairly confident this is correct.